### PR TITLE
Add OpenAI integration with selectable model and STT/TTS providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+VITE_OPENAI_API_KEY=your_openai_api_key
+VITE_OPENAI_MODEL=gpt-3.5-turbo
+VITE_STT_PROVIDER=openai
+VITE_TTS_PROVIDER=browser

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ node_modules
 dist
 dist-ssr
 *.local
+*.env
+.env.local
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This contains everything you need to run your app locally.
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Copy `.env.example` to `.env.local` and set `VITE_OPENAI_API_KEY` to your OpenAI key.
+   You can also adjust `VITE_OPENAI_MODEL`, `VITE_STT_PROVIDER`, and `VITE_TTS_PROVIDER`.
 3. Run the app:
    `npm run dev`

--- a/config.ts
+++ b/config.ts
@@ -1,0 +1,2 @@
+export const STT_PROVIDER = (import.meta.env.VITE_STT_PROVIDER || 'browser') as 'browser' | 'openai';
+export const TTS_PROVIDER = (import.meta.env.VITE_TTS_PROVIDER || 'browser') as 'browser' | 'openai';

--- a/services/openAiService.ts
+++ b/services/openAiService.ts
@@ -1,0 +1,67 @@
+const OPENAI_KEY = import.meta.env.VITE_OPENAI_API_KEY as string | undefined;
+
+if (!OPENAI_KEY) {
+  console.warn('[openAiService] OPENAI API key is not set.');
+}
+
+const CHAT_MODEL = import.meta.env.VITE_OPENAI_MODEL || 'gpt-3.5-turbo';
+
+export async function chatCompletion(messages: {role: 'system' | 'user' | 'assistant'; content: string;}[], model: string = CHAT_MODEL): Promise<string> {
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${OPENAI_KEY}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model,
+      messages
+    })
+  });
+  if (!res.ok) {
+    throw new Error(`OpenAI chat error: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.choices[0].message.content.trim();
+}
+
+export async function transcribeAudio(audio: Blob): Promise<string> {
+  const form = new FormData();
+  form.append('file', audio, 'audio.webm');
+  form.append('model', 'whisper-1');
+
+  const res = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${OPENAI_KEY}`
+    },
+    body: form
+  });
+  if (!res.ok) {
+    throw new Error(`OpenAI STT error: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.text as string;
+}
+
+export async function synthesizeSpeech(text: string, voice: string = 'alloy'): Promise<Blob> {
+  const res = await fetch('https://api.openai.com/v1/audio/speech', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${OPENAI_KEY}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model: 'tts-1',
+      input: text,
+      voice
+    })
+  });
+  if (!res.ok) {
+    throw new Error(`OpenAI TTS error: ${res.status}`);
+  }
+  const arrayBuffer = await res.arrayBuffer();
+  return new Blob([arrayBuffer], { type: 'audio/mpeg' });
+}
+
+export const AVAILABLE_MODELS = ['gpt-3.5-turbo', 'gpt-4o'];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,12 +2,8 @@ import path from 'path';
 import { defineConfig, loadEnv } from 'vite';
 
 export default defineConfig(({ mode }) => {
-    const env = loadEnv(mode, '.', '');
+    loadEnv(mode, '.', '');
     return {
-      define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
-      },
       resolve: {
         alias: {
           '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
## Summary
- use `.env.example` to document environment vars
- ignore env files
- add OpenAI service for chat, STT and TTS
- allow choosing STT/TTS provider via `config.ts`
- update RecordFlow and ChatInputArea to optionally use OpenAI STT
- use ChatGPT for chat replies in ChatPage
- update README for new setup instructions
- clean up vite config

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684491e71f68832ebf0b4db28663ab93