### PR TITLE
Implement Google login fallback

### DIFF
--- a/AuthContext.tsx
+++ b/AuthContext.tsx
@@ -5,6 +5,7 @@ import { supabase } from './supabaseClient';
 interface AuthContextValue {
   user: User | null;
   session: Session | null;
+  loading: boolean;
   signInWithGoogle: () => Promise<void>;
   signInWithEmail: (email: string, password: string) => Promise<void>;
   signUpWithEmail: (email: string, password: string) => Promise<void>;
@@ -16,6 +17,7 @@ const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [session, setSession] = useState<Session | null>(null);
   const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
@@ -28,13 +30,27 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       }
     });
 
-    const stored = localStorage.getItem('sb-session');
-    if (stored) {
-      const parsed = JSON.parse(stored) as Session;
-      setSession(parsed);
-      setUser(parsed.user);
-      supabase.auth.setSession(parsed).catch(() => {});
-    }
+    const init = async () => {
+      await supabase.auth.getSessionFromUrl().catch(() => {});
+      await supabase.auth.exchangeCodeForSession(window.location.href).catch(() => {});
+      const { data } = await supabase.auth.getSession();
+      if (data.session) {
+        setSession(data.session);
+        setUser(data.session.user);
+      } else {
+        const stored = localStorage.getItem('sb-session');
+        if (stored) {
+          try {
+            const parsed = JSON.parse(stored) as Session;
+            setSession(parsed);
+            setUser(parsed.user);
+            supabase.auth.setSession(parsed).catch(() => {});
+          } catch {}
+        }
+      }
+      setLoading(false);
+    };
+    init();
 
     return () => {
       subscription.unsubscribe();
@@ -42,7 +58,15 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   }, []);
 
   const signInWithGoogle = async () => {
-    await supabase.auth.signInWithOAuth({ provider: 'google', options: { redirectTo: window.location.origin } });
+    try {
+      const { error } = await supabase.auth.signInWithOAuth({ provider: 'google' });
+      if (error && /Popup/.test(error.message)) throw error;
+    } catch {
+      await supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: { redirectTo: window.location.origin }
+      });
+    }
   };
 
   const signInWithEmail = async (email: string, password: string) => {
@@ -60,7 +84,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   };
 
   return (
-    <AuthContext.Provider value={{ user, session, signInWithGoogle, signInWithEmail, signUpWithEmail, signOut }}>
+    <AuthContext.Provider value={{ user, session, loading, signInWithGoogle, signInWithEmail, signUpWithEmail, signOut }}>
       {children}
     </AuthContext.Provider>
   );

--- a/ProtectedRoute.tsx
+++ b/ProtectedRoute.tsx
@@ -3,8 +3,15 @@ import { Navigate, Outlet } from 'react-router-dom';
 import { useAuth } from './AuthContext';
 
 export const ProtectedRoute: React.FC = () => {
-  const { user } = useAuth();
-  if (!user) {
+  const { user, loading } = useAuth();
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-white" />
+      </div>
+    );
+  }
+  if (!user && !loading) {
     return <Navigate to="/login" replace />;
   }
   return <Outlet />;

--- a/components/DebugUserId.tsx
+++ b/components/DebugUserId.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { useAuth } from '../AuthContext';
+
+export const DebugUserId: React.FC = () => {
+  const { session } = useAuth();
+  if (!import.meta.env.DEV) return null;
+  return <div className="text-xs mt-2">User: {session?.user.id}</div>;
+};

--- a/pages/LoginPage.tsx
+++ b/pages/LoginPage.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
+import { supabase } from '../supabaseClient';
 
 export const LoginPage: React.FC = () => {
-  const { signInWithGoogle, signInWithEmail, signUpWithEmail } = useAuth();
+  const { signInWithEmail, signUpWithEmail } = useAuth();
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -21,6 +22,18 @@ export const LoginPage: React.FC = () => {
       navigate('/dashboard', { replace: true });
     } catch (err: any) {
       setError(err.message);
+    }
+  };
+
+  const signInWithGoogle = async () => {
+    try {
+      const { error } = await supabase.auth.signInWithOAuth({ provider: 'google' });
+      if (error && /Popup/.test(error.message)) throw error;
+    } catch {
+      await supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: { redirectTo: window.location.origin }
+      });
     }
   };
 


### PR DESCRIPTION
## Summary
- handle Supabase sessions from URL before checking existing session
- implement Google sign-in popup with redirect fallback
- show spinner while auth state resolves
- expose a debug helper for development

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845fd658f18832e92fd313a4e2f2b42