### PR TITLE
Fix auth redirect and remove binary icons

### DIFF
--- a/AuthContext.tsx
+++ b/AuthContext.tsx
@@ -5,6 +5,7 @@ import { supabase } from './supabaseClient';
 interface AuthContextValue {
   user: User | null;
   session: Session | null;
+  loading: boolean;
   signInWithGoogle: () => Promise<void>;
   signInWithEmail: (email: string, password: string) => Promise<void>;
   signUpWithEmail: (email: string, password: string) => Promise<void>;
@@ -16,25 +17,24 @@ const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [session, setSession] = useState<Session | null>(null);
   const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
+    const init = async () => {
+      const { data } = await supabase.auth.getSession();
+      if (data.session) {
+        setSession(data.session);
+        setUser(data.session.user);
+      }
+      setLoading(false);
+    };
+
+    init();
+
     const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
       setSession(session);
       setUser(session?.user ?? null);
-      if (session) {
-        localStorage.setItem('sb-session', JSON.stringify(session));
-      } else {
-        localStorage.removeItem('sb-session');
-      }
     });
-
-    const stored = localStorage.getItem('sb-session');
-    if (stored) {
-      const parsed = JSON.parse(stored) as Session;
-      setSession(parsed);
-      setUser(parsed.user);
-      supabase.auth.setSession(parsed).catch(() => {});
-    }
 
     return () => {
       subscription.unsubscribe();
@@ -60,7 +60,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   };
 
   return (
-    <AuthContext.Provider value={{ user, session, signInWithGoogle, signInWithEmail, signUpWithEmail, signOut }}>
+    <AuthContext.Provider value={{ user, session, loading, signInWithGoogle, signInWithEmail, signUpWithEmail, signOut }}>
       {children}
     </AuthContext.Provider>
   );

--- a/ProtectedRoute.tsx
+++ b/ProtectedRoute.tsx
@@ -3,7 +3,12 @@ import { Navigate, Outlet } from 'react-router-dom';
 import { useAuth } from './AuthContext';
 
 export const ProtectedRoute: React.FC = () => {
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return <div className="flex items-center justify-center h-full">Loading...</div>;
+  }
+
   if (!user) {
     return <Navigate to="/login" replace />;
   }

--- a/index.css
+++ b/index.css
@@ -1,0 +1,1 @@
+/* Custom styles placeholder */

--- a/pages/LoginPage.tsx
+++ b/pages/LoginPage.tsx
@@ -3,12 +3,16 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
 
 export const LoginPage: React.FC = () => {
-  const { signInWithGoogle, signInWithEmail, signUpWithEmail } = useAuth();
+  const { user, loading, signInWithGoogle, signInWithEmail, signUpWithEmail } = useAuth();
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isSignUp, setIsSignUp] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  if (!loading && user) {
+    navigate('/dashboard', { replace: true });
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,40 +5,10 @@
   "description": "Improve your English pronunciation with AI-powered feedback and personalized lessons.",
   "icons": [
     {
-      "src": "/icons/icon-72x72.png",
-      "type": "image/png",
-      "sizes": "72x72"
-    },
-    {
-      "src": "/icons/icon-96x96.png",
-      "type": "image/png",
-      "sizes": "96x96"
-    },
-    {
-      "src": "/icons/icon-128x128.png",
-      "type": "image/png",
-      "sizes": "128x128"
-    },
-    {
-      "src": "/icons/icon-144x144.png",
-      "type": "image/png",
-      "sizes": "144x144"
-    },
-    {
-      "src": "/icons/icon-152x152.png",
-      "type": "image/png",
-      "sizes": "152x152"
-    },
-    {
       "src": "/icons/icon-192x192.png",
       "type": "image/png",
       "sizes": "192x192",
       "purpose": "any maskable"
-    },
-    {
-      "src": "/icons/icon-384x384.png",
-      "type": "image/png",
-      "sizes": "384x384"
     },
     {
       "src": "/icons/icon-512x512.png",


### PR DESCRIPTION
## Summary
- ensure session initializes on app start in `AuthContext`
- handle loading state in `ProtectedRoute` and redirect if logged in on login page
- add placeholder CSS file
- remove non-essential icon assets and update manifest

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68460e7b4438832e8f2bcc959229c647